### PR TITLE
fix for JENKINS-8658 (jenkins still picks ~/.hudson as default when ran using java -jar)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.3</source>
-          <target>1.3</target>
+          <source>1.5</source>
+          <target>1.5</target>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Related to https://github.com/jenkinsci/jenkins/pull/27 for the fix to work.

Note that the 2 pull requests contains more than what is required for the fix to work. It also add displaying information in the console to help troubleshoot environment issues related to identifying the homeDir.

Let me know if you want me to split those commits further.
