### PR TITLE
[FIXED JENKINS-34287] CLI over HTTP no longer functions

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -170,11 +170,6 @@ public class Main {
         // this is so that JFreeChart can work nicely even if we are launched as a daemon
         System.setProperty("java.awt.headless","true");
 
-        // tell Jenkins that Winstone doesn't support chunked encoding.
-        // this is no longer neede for Winstone 2.x
-        if(System.getProperty("hudson.diyChunking")==null)
-            System.setProperty("hudson.diyChunking","true");
-
         File me = whoAmI(extractedFilesFolder);
         System.out.println("Running from: " + me);
         System.setProperty("executable-war",me.getAbsolutePath());  // remember the location so that we can access it from within webapp


### PR DESCRIPTION
CLI is not functioning properly over HTTP due to setting system property `hudson.diyChunking=true`

This fixes: https://issues.jenkins-ci.org/browse/JENKINS-34287

@reviewbybees 