### PR TITLE
[JENKINS-22088] Disk space leak 

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -440,17 +440,17 @@ public class Main {
         if(files != null){
             for (File file : files) {
                 LOGGER.log(Level.FINE, "Deleting the temporary file {0}", file);
-                deleteContentsFromFolder(file);
+                deleteWinstoneTempContents(file);
             }
         }
     }
 
-    private static void deleteContentsFromFolder(File file) throws IOException {
+    private static void deleteWinstoneTempContents(File file) throws IOException {
         if(file.isDirectory()) {
             File[] files = file.listFiles();
             if(files!=null) {// be defensive
                 for (int i = 0; i < files.length; i++)
-                    deleteContentsFromFolder(files[i]);
+                    deleteWinstoneTempContents(files[i]);
             }
         }
         if (!file.delete()) {

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -27,6 +27,7 @@ import javax.naming.NamingException;
 import javax.naming.Context;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -226,6 +227,8 @@ public class Main {
             arguments.add("--webroot="+new File(describedHomeDir.file,"war"));
         }
 
+        deleteWinstoneTempContents(extractedFilesFolder,"winstone.*\\.jar", "jna-.*");
+
         // put winstone jar in a file system so that we can load jars from there
         File tmpJar = extractFromJar("winstone.jar","winstone",".jar", extractedFilesFolder);
         tmpJar.deleteOnExit();
@@ -412,6 +415,30 @@ public class Main {
         }
         tmp.deleteOnExit();
         return tmp;
+    }
+
+    private static void deleteWinstoneTempContents(File folder, final String...patterns) throws IOException {
+        File tmpdir = folder;
+
+        if(tmpdir == null){
+            tmpdir = new File(System.getProperty("java.io.tmpdir"));
+        }
+
+        final File[] files = tmpdir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(final File dir, final String name) {
+                for (String pattern : patterns) {
+                    if(name.matches(pattern)){
+                        return true;
+                    }
+                }
+                return false;
+            }
+        });
+        for (File file : files) {
+            LOGGER.log(Level.FINE, "Deleting the temporary file {0}", file);
+            deleteWinstoneTempContents(file);
+        }
     }
 
     private static void deleteWinstoneTempContents(File file) throws IOException {

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -239,7 +239,7 @@ public class Main {
         // winstone doesn't do so and that causes problems when newer version of Jenkins
         // is deployed.
         File tempFile = File.createTempFile("dummy", "dummy");
-        deleteContentsFromFolder(new File(tempFile.getParent(), "winstone/" + me.getName()));
+        deleteWinstoneTempContents(new File(tempFile.getParent(), "winstone/" + me.getName()));
         if (!tempFile.delete()) {
             LOGGER.log(Level.WARNING, "Failed to delete the temporary file {0}", tempFile);
         }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -426,21 +426,16 @@ public class Main {
      * @throws IOException in case of error deleting contents.
      */
     private static void deleteContentsFromFolder(File folder, final String...patterns) throws IOException {
-        final File[] files = folder.listFiles(new FilenameFilter() {
-            @Override
-            public boolean accept(final File dir, final String name) {
-                for (String pattern : patterns) {
-                    if(name.matches(pattern)){
-                        return true;
-                    }
-                }
-                return false;
-            }
-        });
+        File[]  files = folder.listFiles();
+
         if(files != null){
             for (File file : files) {
-                LOGGER.log(Level.FINE, "Deleting the temporary file {0}", file);
-                deleteWinstoneTempContents(file);
+                for (String pattern : patterns) {
+                    if(file.getName().matches(pattern)){
+                        LOGGER.log(Level.FINE, "Deleting the temporary file {0}", file);
+                        deleteWinstoneTempContents(file);
+                    }
+                }
             }
         }
     }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -227,7 +227,10 @@ public class Main {
             arguments.add("--webroot="+new File(describedHomeDir.file,"war"));
         }
 
-        deleteWinstoneTempContents(extractedFilesFolder,"winstone.*\\.jar");
+        //only do a cleanup if you set the extractedFilesFolder property.
+        if(extractedFilesFolder != null) {
+            deleteWinstoneTempContents(extractedFilesFolder, "winstone.*\\.jar");
+        }
 
         // put winstone jar in a file system so that we can load jars from there
         File tmpJar = extractFromJar("winstone.jar","winstone",".jar", extractedFilesFolder);

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -227,7 +227,7 @@ public class Main {
             arguments.add("--webroot="+new File(describedHomeDir.file,"war"));
         }
 
-        deleteWinstoneTempContents(extractedFilesFolder,"winstone.*\\.jar", "jna-.*");
+        deleteWinstoneTempContents(extractedFilesFolder,"winstone.*\\.jar");
 
         // put winstone jar in a file system so that we can load jars from there
         File tmpJar = extractFromJar("winstone.jar","winstone",".jar", extractedFilesFolder);


### PR DESCRIPTION
[JENKINS-22088](https://issues.jenkins-ci.org/browse/JENKINS-22088)

Disk space leak with multiple copies of winstone-XXXX.jar in TEMP folder
It fails to do the deleteOnExit on Mac OS, windows, and probably Linux, the solution proposed is to scan the temporal folder with a pattern and delete the files.

@reviewbybees