### PR TITLE
added ability to supply args via stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,12 @@ In such case it becomes configurable via [Jetty configuration](http://www.eclips
 Sets a custom Session ID Cookie name when `disableCustomSessionIdCookieName` is `false`.
 In such case the Jenkins administrator is responsible for preventing cookie collisions between Jenkins instances.
 
+### Parameters from stdin
+
+When parameters are passed via command line they can be viewed using ps in *nix, process explorer in Windows as long as the process keeps running. This is undesirable when passing sensitive parameters like httpsKeyStorePassword.
+
+It is now possible to pass parameters through stdin. To do this pass '--paramsFromStdIn' parameter and you will be able to replace this:
+`java -jar jenkins.war --httpPort=-1 --httpsPort=443 --httpsKeyStore=path/to/keystore --httpsKeyStorePassword=keystorePassword`
+with this:
+`echo "--httpPort=-1 --httpsPort=443 --httpsKeyStore=path/to/keystore --httpsKeyStorePassword=keystorePassword" | java -jar jenkins.war --paramsFromStdIn`
 

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -138,6 +138,11 @@ public class Main {
     }
 
     private static void _main(String[] args) throws Exception {
+        //Allows to pass arguments through stdin to "hide" sensitive parameters like httpsKeyStorePassword
+        if(args.length == 0) {
+            String argsInStdIn = readStringNonBlocking(System.in,131072).trim();
+            args = argsInStdIn.split(" +");
+        }
         // If someone just wants to know the version, print it out as soon as possible, with no extraneous file or webroot info.
         // This makes it easier to grab the version from a script
         final List<String> arguments = new ArrayList(Arrays.asList(args));
@@ -294,6 +299,19 @@ public class Main {
         mainMethod.invoke(null,new Object[]{arguments.toArray(new String[0])});
     }
 
+    /**
+     * reads up to maxRead bytes from InputStream if available into a String
+     *
+     * @param in
+     * @param maxToRead
+     * @return
+     * @throws IOException
+     */
+    private static String readStringNonBlocking(InputStream in, int maxToRead) throws IOException {
+        byte [] buffer = new byte[Math.min(in.available(), maxToRead)];
+        in.read(buffer);
+        return new String(buffer);
+	}
     private static void trimOffOurOptions(List arguments) {
         for (Iterator itr = arguments.iterator(); itr.hasNext(); ) {
             String arg = (String) itr.next();

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -311,7 +311,7 @@ public class Main {
         byte [] buffer = new byte[Math.min(in.available(), maxToRead)];
         in.read(buffer);
         return new String(buffer);
-	}
+    }
     private static void trimOffOurOptions(List arguments) {
         for (Iterator itr = arguments.iterator(); itr.hasNext(); ) {
             String arg = (String) itr.next();

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -302,10 +302,10 @@ public class Main {
     /**
      * reads up to maxRead bytes from InputStream if available into a String
      *
-     * @param in
-     * @param maxToRead
-     * @return
-     * @throws IOException
+     * @param in input stream to be read
+     * @param maxToRead maximum number of bytes to read from the in
+     * @return a String read from in
+     * @throws IOException when reading in caused it
      */
     private static String readStringNonBlocking(InputStream in, int maxToRead) throws IOException {
         byte [] buffer = new byte[Math.min(in.available(), maxToRead)];

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -139,9 +139,14 @@ public class Main {
 
     private static void _main(String[] args) throws Exception {
         //Allows to pass arguments through stdin to "hide" sensitive parameters like httpsKeyStorePassword
-        if(args.length == 0) {
-            String argsInStdIn = readStringNonBlocking(System.in,131072).trim();
-            args = argsInStdIn.split(" +");
+        //to achieve this use --paramsFromStdIn
+        for (String arg:args){
+            if ("--paramsFromStdIn".equals(arg)) {
+                System.out.println("--paramsFromStdIn detected. Parameters are going to be read from stdin. Other parameters passed directly will be ignored.");
+                String argsInStdIn = readStringNonBlocking(System.in,131072).trim();
+                args = argsInStdIn.split(" +");
+                break;
+            }
         }
         // If someone just wants to know the version, print it out as soon as possible, with no extraneous file or webroot info.
         // This makes it easier to grab the version from a script


### PR DESCRIPTION
When parameters are passed via command line they can be viewed using ps in *nix, process explorer in Windows as long as the process keeps running. This is undesirable when passing sensitive parameters like httpsKeyStorePassword. This change allows to pass parameters via stdin.
Effectively you can replace this:

```
java -jar jenkins.war --httpPort=-1 --httpsPort=443 --httpsKeyStore=path/to/keystore --httpsKeyStorePassword=keystorePassword
```

with this:

```
echo "--httpPort=-1 --httpsPort=443 --httpsKeyStore=path/to/keystore --httpsKeyStorePassword=keystorePassword" | java -jar jenkins.war
```