### PR TITLE
[JENKINS-50439] Remove spurious warning when starting Jenkins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 ====
 
+### 1.39
+
+Release date: Mar 28, 2018
+
+* [JENKINS-50439](https://issues.jenkins-ci.org/browse/JENKINS-50439) -
+  Remove spurious warning when starting Jenkins
+
 ### 1.38
 
 Release date: Mar 10, 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog
 Release date: Mar 28, 2018
 
 * [JENKINS-50439](https://issues.jenkins-ci.org/browse/JENKINS-50439) -
-  Remove spurious warning when starting Jenkins
+  Remove spurious "Failed to delete the temporary Winstone file /tmp/winstone/jenkins-2.x.war" warning when starting Jenkins
 
 ### 1.38
 

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -475,6 +475,10 @@ public class Main {
     }
 
     private static void deleteWinstoneTempContents(File file) throws IOException {
+        if (!file.exists()) {
+            LOGGER.log(Level.FINEST, "No file found at {0}, nothing to delete.", file);
+            return;
+        }
         if(file.isDirectory()) {
             File[] files = file.listFiles();
             if(files!=null) {// be defensive


### PR DESCRIPTION
I found this as I was working on analyzing logs for Essentials, we see the following WARNING log each time we start Jenkins:

```
Mar 27, 2018 10:04:00 PM Main deleteWinstoneTempContents
WARNING: Failed to delete the temporary Winstone file /tmp/winstone/jenkins-2.112.war
```

Testing my machine the current fix made the log disappear.

@reviewbybees 