### PR TITLE
[JENKINS-51155] - Add the --enable-future-java flag, which allows running with not-yet-supported Java versions

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -127,18 +127,27 @@ public class Main {
             if (v!=null) {
                 try {
                     float javaVersion = Float.parseFloat(v);
-                    if (javaVersion != REQUIRED_JAVA_VERSION) {
+                    //TODO: add support of version ranges instead of equality check
+                    if (javaVersion == REQUIRED_JAVA_VERSION) {
+                        // Fine
+                    } else if (javaVersion > REQUIRED_JAVA_VERSION) {
                         Error error = new UnsupportedClassVersionError(v);
-                        if (javaVersion > REQUIRED_JAVA_VERSION && hasArgument("--enable-future-java", args)) {
+                        if (hasArgument("--enable-future-java", args)) {
                             LOGGER.log(Level.WARNING,
                                     String.format("Running with Java class version %s, but %s is required." +
-                                            "Argument --enable-future-java is set, so will continue.", javaVersion, REQUIRED_JAVA_VERSION));
+                                            "Argument --enable-future-java is set, so will continue", javaVersion, REQUIRED_JAVA_VERSION));
                         } else {
                             LOGGER.log(Level.SEVERE, String.format("Running with Java class version %s, but %s is required." +
                                     "Run with the --enable-future-java flag to enable such behavior",
                                     javaVersion, REQUIRED_JAVA_VERSION), error);
                             throw error;
                         }
+                    } else {
+                        Error error = new UnsupportedClassVersionError(v);
+                        LOGGER.log(Level.SEVERE,
+                                String.format("Running with Java class version %s, which is older than the required %s",
+                                        javaVersion, REQUIRED_JAVA_VERSION), error);
+                        throw error;
                     }
                 } catch (NumberFormatException e) {
                     // err on the safe side and keep on going

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -131,12 +131,12 @@ public class Main {
                     if (javaVersion == REQUIRED_JAVA_VERSION) {
                         // Fine
                     } else if (javaVersion > REQUIRED_JAVA_VERSION) {
-                        Error error = new UnsupportedClassVersionError(v);
                         if (hasArgument("--enable-future-java", args)) {
                             LOGGER.log(Level.WARNING,
                                     String.format("Running with Java class version %s, but %s is required." +
                                             "Argument --enable-future-java is set, so will continue", javaVersion, REQUIRED_JAVA_VERSION));
                         } else {
+                            Error error = new UnsupportedClassVersionError(v);
                             LOGGER.log(Level.SEVERE, String.format("Running with Java class version %s, but %s is required." +
                                     "Run with the --enable-future-java flag to enable such behavior",
                                     javaVersion, REQUIRED_JAVA_VERSION), error);


### PR DESCRIPTION
Starting from 1.38, Jenkins startup fails if Java is newer than Java 8 (class format 52.0). It was an intentional change, because we were getting a number of error reports from users.

Next week we will have a Java 10 hackathon, and I propose to add a command-line flag which permits running on newer Java versions (with a warning being printed).

https://issues.jenkins-ci.org/browse/JENKINS-51155

@jenkinsci/code-reviewers @MarkEWaite 
