### PR TITLE
[JENKINS-46622] - Prevent the Reflective access warning.

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -423,9 +423,7 @@ public class Main {
         try {
             URL classFile = Main.class.getClassLoader().getResource("Main.class");
             JarFile jf = ((JarURLConnection) classFile.openConnection()).getJarFile();
-            Field f = ZipFile.class.getDeclaredField("name");
-            f.setAccessible(true);
-            return new File((String) f.get(jf));
+            return new File(jf.getName());
         } catch (Exception x) {
             System.err.println("ZipFile.name trick did not work, using fallback: " + x);
         }


### PR DESCRIPTION
API is available since Java 5, sound safe to update

@jenkinsci/java10-support 
