### PR TITLE
[JENKINS-52285] - Update Extras Executable WAR to support multiple versions + Java 11 silent launch

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -68,6 +68,8 @@ import java.util.zip.ZipFile;
 public class Main {
     
     private static final String DEPENDENCIES_LIST = "WEB-INF/classes/dependencies.txt";
+    private static final Set<Integer> SUPPORTED_JAVA_VERSIONS =
+            new HashSet<Integer>(Arrays.asList(8, 11));
     private static final Set<Integer> SUPPORTED_JAVA_CLASS_VERSIONS =
             new HashSet<Integer>(Arrays.asList(52, 55));
     private static final int MINIMUM_JAVA_CLASS_VERSION = 52;
@@ -173,8 +175,10 @@ public class Main {
 
             _main(args);
         } catch (UnsupportedClassVersionError e) {
-            System.err.println("Jenkins requires Java 8, but you are running "+
-                System.getProperty("java.runtime.version")+" from "+System.getProperty("java.home"));
+            System.err.println(String.format(
+                    "Jenkins requires Java versions %s but you are running with Java %s from %s",
+                    SUPPORTED_JAVA_VERSIONS, System.getProperty("java.specification.version"), System.getProperty("java.home"))
+            );
             e.printStackTrace();
         }
     }

--- a/src/test/java/MainTest.java
+++ b/src/test/java/MainTest.java
@@ -6,13 +6,9 @@ import org.jvnet.hudson.test.Issue;
 import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 @For(Main.class)
 public class MainTest {
-
-    private static final Logger LOGGER = Logger.getLogger(MainTest.class.getName());
 
     @Test(expected = IOException.class)
     public void shouldHaveNoStandardDependenciesFile() throws IOException {
@@ -64,7 +60,9 @@ public class MainTest {
             Main.verifyJavaVersion(classVersion, enableFutureJava);
         } catch (Error error) {
             failed = true;
-            LOGGER.log(Level.WARNING, "Java class version check failed as it was expected", error);
+            System.out.println(String.format("Java class version check failed as it was expected for Java class version %s.0 and enableFutureJava=%s",
+                classVersion, enableFutureJava));
+            error.printStackTrace(System.out);
         }
 
         if (!failed) {
@@ -83,9 +81,8 @@ public class MainTest {
         try {
             Main.verifyJavaVersion(classVersion, enableFutureJava);
         } catch (Error error) {
-            LOGGER.log(Level.WARNING, "Java class version check failed as it was expected", error);
             AssertionError err = new AssertionError(message != null ? message :
-                    String.format("Java version Check should have failed for Java class version %s.0 and enableFutureJava=%s",
+                    String.format("Java version Check should have passed for Java class version %s.0 and enableFutureJava=%s",
                             classVersion, enableFutureJava));
             err.initCause(error);
             throw err;

--- a/src/test/java/MainTest.java
+++ b/src/test/java/MainTest.java
@@ -1,14 +1,94 @@
+import org.junit.Assert;
 import org.junit.Test;
 import org.jvnet.hudson.test.For;
+import org.jvnet.hudson.test.Issue;
 
+import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @For(Main.class)
 public class MainTest {
 
+    private static final Logger LOGGER = Logger.getLogger(MainTest.class.getName());
+
     @Test(expected = IOException.class)
     public void shouldHaveNoStandardDependenciesFile() throws IOException {
         final Map<String, String> versions = Main.parseDependencyVersions();
+    }
+
+    @Test
+    public void shouldFailForOldJava() {
+        assertJavaCheckFails(51, false);
+        assertJavaCheckFails(51, true);
+    }
+
+    @Test
+    public void shouldBeOkForJava8() {
+        assertJavaCheckPasses(52, false);
+        assertJavaCheckPasses(52, true);
+    }
+
+    @Test
+    public void shouldFailForMidJavaVersionsIfNoFlag() {
+        assertJavaCheckFails(53, false);
+        assertJavaCheckFails(54, false);
+        assertJavaCheckPasses(53, true);
+        assertJavaCheckPasses(54, true);
+    }
+
+    @Test
+    @Issue("JENKINS-51805")
+    public void shouldBeOkForJava11() {
+        assertJavaCheckPasses(55, false);
+        assertJavaCheckPasses(55, true);
+    }
+
+    @Test
+    public void shouldFailForNewJavaVersionsIfNoFlag() {
+        assertJavaCheckFails(56, false);
+        assertJavaCheckFails(57, false);
+        assertJavaCheckPasses(56, true);
+        assertJavaCheckPasses(57, true);
+    }
+
+    public void assertJavaCheckFails(int classVersion, boolean enableFutureJava) {
+        assertJavaCheckFails(null, classVersion, enableFutureJava);
+    }
+
+    public void assertJavaCheckFails(@CheckForNull String message, int classVersion, boolean enableFutureJava) {
+        boolean failed = false;
+        try {
+            Main.verifyJavaVersion(classVersion, enableFutureJava);
+        } catch (Error error) {
+            failed = true;
+            LOGGER.log(Level.WARNING, "Java class version check failed as it was expected", error);
+        }
+
+        if (!failed) {
+            Assert.fail(message != null ? message :
+                    String.format("Java version Check should have failed for Java class version %s.0 and enableFutureJava=%s",
+                            classVersion, enableFutureJava));
+        }
+    }
+
+    public void assertJavaCheckPasses(int classVersion, boolean enableFutureJava) {
+        assertJavaCheckPasses(null, classVersion, enableFutureJava);
+    }
+
+    public void assertJavaCheckPasses(@CheckForNull String message, int classVersion, boolean enableFutureJava) {
+        boolean failed = false;
+        try {
+            Main.verifyJavaVersion(classVersion, enableFutureJava);
+        } catch (Error error) {
+            LOGGER.log(Level.WARNING, "Java class version check failed as it was expected", error);
+            AssertionError err = new AssertionError(message != null ? message :
+                    String.format("Java version Check should have failed for Java class version %s.0 and enableFutureJava=%s",
+                            classVersion, enableFutureJava));
+            err.initCause(error);
+            throw err;
+        }
     }
 }


### PR DESCRIPTION
This change updates the version check logic in Extras Executable WAR.

- [x] - Rework the version comparison logic. Now it supports version sets
- [x] - Allow running with Java 11 without setting a, `--enable-future-java` flag. It is OK to do it after JAXB patches in 2.163, so we can silently enable it before the official GA announcement

https://issues.jenkins-ci.org/browse/JENKINS-52285