### PR TITLE
Remove `--daemon` option

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -338,18 +338,6 @@ public class Main {
                 || arg.startsWith("--pluginroot") || arg.startsWith(ENABLE_FUTURE_JAVA_CLI_SWITCH));
     }
 
-    private static String getVersion(Map<String,String> revisions, String groupId, String artifactId) {
-        String v = revisions.get(groupId + ":" + artifactId);
-        if (v==null) {
-            // fall back to artifact ID only search, in case the artifact is renamed
-            for (String key : revisions.keySet()) {
-                if (key.endsWith(":" + artifactId))
-                    return v;
-            }
-        }
-        return v;
-    }
-
     /**
      * Figures out the version from the manifest.
      */

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -95,34 +95,6 @@ public class Main {
      */
     private static final String ENABLE_FUTURE_JAVA_CLI_SWITCH = "--enable-future-java";
 
-    /**
-     * Reads <tt>WEB-INF/classes/dependencies.txt and builds "groupId:artifactId" -> "version" map.
-     */
-    //TODO: Bug, not a feature
-    @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "Legacy behavior. We do not know which encoding was used to generate WEB-INF/classes/dependencies.txt")
-    /*package*/ static Map<String,String> parseDependencyVersions() throws IOException {
-        
-        final InputStream dependenciesInputStream = Main.class.getResourceAsStream(DEPENDENCIES_LIST);
-        if (dependenciesInputStream == null) {
-            throw new IOException("Cannot find resource " + DEPENDENCIES_LIST);
-        }
-        final Map<String,String> r = new HashMap<>();
-        try {
-            try (BufferedReader in = new BufferedReader(new InputStreamReader(dependenciesInputStream))) {
-                String line;
-                while ((line = in.readLine()) != null) {
-                    line = line.trim();
-                    String[] tokens = line.split(":");
-                    if (tokens.length != 5) continue;   // there should be 5 tuples group:artifact:type:version:scope
-                    r.put(tokens[0] + ":" + tokens[1], tokens[3]);
-                }
-            }
-        } finally {
-            dependenciesInputStream.close();
-        }
-        return r;
-    }
-
     public static void main(String[] args) throws Exception {
         try {
             String v = System.getProperty("java.class.version");

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -233,33 +233,6 @@ public class Main {
             }
         }
 
-        // if we need to daemonize, do it first
-        for (int i = 0; i < args.length; i++) {
-            if(args[i].startsWith("--daemon")) {
-                Map<String, String> revisions = parseDependencyVersions();
-
-                // load the daemonization code
-                ClassLoader cl = new URLClassLoader(new URL[]{
-                    extractFromJar("WEB-INF/lib/jna-"+getVersion(revisions, "net.java.dev.jna", "jna") +".jar","jna","jar", extractedFilesFolder).toURI().toURL(),
-                    extractFromJar("WEB-INF/lib/akuma-"+getVersion(revisions,"org.kohsuke","akuma")+".jar","akuma","jar", extractedFilesFolder).toURI().toURL(),
-                });
-                Class $daemon = cl.loadClass("com.sun.akuma.Daemon");
-                Object daemon = $daemon.newInstance();
-
-                // tell the user that we'll be starting as a daemon.
-                Method isDaemonized = $daemon.getMethod("isDaemonized", new Class[]{});
-                if(!((Boolean)isDaemonized.invoke(daemon,new Object[0])).booleanValue()) {
-                    System.out.println("Forking into background to run as a daemon.");
-                    if(!hasOption(arguments, "--logfile="))
-                        System.out.println("Use --logfile to redirect output to a file");
-                }
-
-                Method m = $daemon.getMethod("all", new Class[]{boolean.class});
-                m.invoke(daemon,new Object[]{Boolean.TRUE});
-            }
-        }
-
-
         // if the output should be redirect to a file, do it now
         for (int i = 0; i < args.length; i++) {
             if(args[i].startsWith("--logfile=")) {
@@ -334,7 +307,6 @@ public class Main {
                 "   --pluginroot             = folder where the plugin archives are expanded into. Default is ${JENKINS_HOME}/plugins\n" +
                 "                              (NOTE: this option does not change the directory where the plugin archives are stored)\n" +
                 "   --extractedFilesFolder   = folder where extracted files are to be located. Default is the temp folder\n" +
-                "   --daemon                 = fork into background and run as daemon (Unix only)\n" +
                 "   --logfile                = redirect log messages to this file\n" +
                 "   " + ENABLE_FUTURE_JAVA_CLI_SWITCH + "     = allows running with new Java versions which are not fully supported (class version " + MINIMUM_JAVA_CLASS_VERSION + " and above)\n" +
                 "{OPTIONS}");
@@ -399,7 +371,7 @@ public class Main {
     private static void trimOffOurOptions(List arguments) {
         for (Iterator itr = arguments.iterator(); itr.hasNext(); ) {
             String arg = (String) itr.next();
-            if (arg.startsWith("--daemon") || arg.startsWith("--logfile") || arg.startsWith("--extractedFilesFolder")
+            if (arg.startsWith("--logfile") || arg.startsWith("--extractedFilesFolder")
                     || arg.startsWith("--pluginroot") || arg.startsWith(ENABLE_FUTURE_JAVA_CLI_SWITCH))
                 itr.remove();
         }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -377,19 +377,6 @@ public class Main {
         }
     }
 
-    private static String getVersion(Map revisions, String groupId, String artifactId) {
-        String v = (String)revisions.get(groupId + ":" + artifactId);
-        if (v==null) {
-            // fall back to artifact ID only search, in case the artifact is renamed
-            for (Iterator itr = revisions.keySet().iterator(); itr.hasNext(); ) {
-                String key = (String) itr.next();
-                if (key.endsWith(":"+artifactId))
-                    return v;
-            }
-        }
-        return v;
-    }
-
     /**
      * Figures out the version from the manifest.
      */

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -197,32 +197,6 @@ public class Main {
             }
         }
 
-        // if we need to daemonize, do it first
-        for (String arg : args) {
-            if (arg.startsWith("--daemon")) {
-                Map<String, String> revisions = parseDependencyVersions();
-
-                // load the daemonization code
-                ClassLoader cl = new URLClassLoader(new URL[]{
-                        extractFromJar("WEB-INF/lib/jna-" + getVersion(revisions, "net.java.dev.jna", "jna") + ".jar", "jna", "jar", extractedFilesFolder).toURI().toURL(),
-                        extractFromJar("WEB-INF/lib/akuma-" + getVersion(revisions, "org.kohsuke", "akuma") + ".jar", "akuma", "jar", extractedFilesFolder).toURI().toURL(),
-                });
-                Class<?> $daemon = cl.loadClass("com.sun.akuma.Daemon");
-                Object daemon = $daemon.newInstance();
-
-                // tell the user that we'll be starting as a daemon.
-                Method isDaemonized = $daemon.getMethod("isDaemonized");
-                if (!(Boolean) isDaemonized.invoke(daemon)) {
-                    System.out.println("Forking into background to run as a daemon.");
-                    if (!hasOption(arguments, "--logfile="))
-                        System.out.println("Use --logfile to redirect output to a file");
-                }
-
-                Method m = $daemon.getMethod("all", boolean.class);
-                m.invoke(daemon, true);
-            }
-        }
-
         // if the output should be redirect to a file, do it now
         for (int i = 0; i < args.length; i++) {
             if(args[i].startsWith("--logfile=")) {

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -35,8 +35,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.lang.reflect.Method;
 import java.lang.reflect.Field;
 import java.net.JarURLConnection;
@@ -49,8 +47,6 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Set;
 import java.util.UUID;
 import java.util.jar.JarFile;
@@ -67,7 +63,6 @@ import java.util.zip.ZipFile;
  */
 public class Main {
     
-    private static final String DEPENDENCIES_LIST = "WEB-INF/classes/dependencies.txt";
     private static final Set<Integer> SUPPORTED_JAVA_VERSIONS =
             new HashSet<Integer>(Arrays.asList(8, 11));
     private static final Set<Integer> SUPPORTED_JAVA_CLASS_VERSIONS =
@@ -100,37 +95,6 @@ public class Main {
      * Flag to bypass the Java version check when starting.
      */
     private static final String ENABLE_FUTURE_JAVA_CLI_SWITCH = "--enable-future-java";
-
-    /**
-     * Reads <tt>WEB-INF/classes/dependencies.txt and builds "groupId:artifactId" -> "version" map.
-     */
-    //TODO: Bug, not a feature
-    @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "Legacy behavior. We do not know which encoding was used to generate WEB-INF/classes/dependencies.txt")
-    /*package*/ static Map<String,String> parseDependencyVersions() throws IOException {
-        
-        final InputStream dependenciesInputStream = Main.class.getResourceAsStream(DEPENDENCIES_LIST);
-        if (dependenciesInputStream == null) {
-            throw new IOException("Cannot find resource " + DEPENDENCIES_LIST);
-        }
-        final Map<String,String> r = new HashMap<String,String>();
-        try {
-            final BufferedReader in = new BufferedReader(new InputStreamReader(dependenciesInputStream));
-            try {
-                String line;
-                while ((line=in.readLine())!=null) {
-                    line = line.trim();
-                    String[] tokens = line.split(":");
-                    if (tokens.length!=5)   continue;   // there should be 5 tuples group:artifact:type:version:scope
-                    r.put(tokens[0]+":"+tokens[1],tokens[3]);
-                }
-            } finally {
-                in.close();
-            }
-        } finally {
-            dependenciesInputStream.close();
-        }
-        return r;
-    }
 
     public static void main(String[] args) throws Exception {
         try {

--- a/src/test/java/MainTest.java
+++ b/src/test/java/MainTest.java
@@ -10,14 +10,6 @@ import java.util.Map;
 @For(Main.class)
 public class MainTest {
 
-    @Test(expected = IOException.class)
-    public void shouldHaveNoStandardDependenciesFile() throws IOException {
-        final Map<String, String> versions = Main.parseDependencyVersions();
-        if (versions == null) {
-            Assert.fail("Main.parseDependencyVersions failed");
-        }
-    }
-
     @Test
     public void shouldFailForOldJava() {
         assertJavaCheckFails(51, false);


### PR DESCRIPTION
I started an effort in June to remove Akuma in jenkinsci/jenkins#5561, but realized that Akuma is still consumed in this repository to implement the `--daemon` feature. I recently asked myself whether that feature is really needed and discovered it was only used in the RPM initialization script, which I removed in jenkinsci/packaging#207. So now there is nothing programmatically consuming `--daemon`. I think it is unlikely that users would be using this option, and if they are it's trivial to instead switch to some utility like `daemon(1)` (on Debian-based systems) or `daemonize(1)` (on RPM-based systems). Dispensing with this `--daemon` feature will allow us, once this PR is merged, released, and pulled into Jenkins core, to proceed with jenkinsci/jenkins#5561 and remove the maintenance burden associated with Akuma.