### PR TITLE
Adopt POM Code Convention

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,7 @@
-<?xml version="1.0"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
@@ -6,13 +9,27 @@
     <relativePath />
   </parent>
 
-  <modelVersion>4.0.0</modelVersion>
   <artifactId>executable-war</artifactId>
-  <name>Executable War 'header'</name>
   <version>${revision}${changelist}</version>
+  <name>Executable War 'header'</name>
   <description>Defines the main() method for a self-contained web application that kickstarts
     embedded Winstone and runs a web application without needing a servlet container.</description>
   <url>https://github.com/jenkinsci/extras-${project.artifactId}</url>
+
+  <licenses>
+    <license>
+      <name>The MIT license</name>
+      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
+  </scm>
 
   <properties>
     <revision>2.4</revision>
@@ -20,13 +37,6 @@
     <java.level>8</java.level>
     <gitHubRepo>jenkinsci/extras-${project.artifactId}</gitHubRepo>
   </properties>
-
-  <scm>
-    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
-    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <url>https://github.com/${gitHubRepo}</url>
-    <tag>${scmTag}</tag>
-  </scm>
 
   <dependencies>
     <dependency>
@@ -65,12 +75,4 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
-  <licenses>
-    <license>
-      <name>The MIT license</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
 </project>


### PR DESCRIPTION
Adopts the [POM Code Convention](https://maven.apache.org/developers/conventions/code.html#pom-code-convention) that was [voted on by Maven developers in 2008](https://lists.apache.org/thread/h8px5t6f3q59cnkzpj1t02wsoynr3ygk). Note that this PR adds no automation; this is just a one-time pass.