### PR TITLE
Allow running on Java 17 without --enable-future-java

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -62,12 +62,14 @@ public class Main {
 
     private static final int MINIMUM_JAVA_VERSION = 8;
     private static final int RECOMMENDED_JAVA_VERSION = 11;
+    private static final int MAXIMUM_JAVA_VERSION = 17;
     private static final Set<Integer> SUPPORTED_JAVA_VERSIONS =
-            new HashSet<>(Arrays.asList(MINIMUM_JAVA_VERSION, RECOMMENDED_JAVA_VERSION));
+            new HashSet<>(Arrays.asList(MINIMUM_JAVA_VERSION, RECOMMENDED_JAVA_VERSION, MAXIMUM_JAVA_VERSION));
     private static final int MINIMUM_JAVA_CLASS_VERSION = 52;
     private static final int RECOMMENDED_JAVA_CLASS_VERSION = 55;
+    private static final int MAXIMUM_JAVA_CLASS_VERSION = 61;
     private static final Set<Integer> SUPPORTED_JAVA_CLASS_VERSIONS =
-            new HashSet<>(Arrays.asList(MINIMUM_JAVA_CLASS_VERSION, RECOMMENDED_JAVA_CLASS_VERSION));
+            new HashSet<>(Arrays.asList(MINIMUM_JAVA_CLASS_VERSION, RECOMMENDED_JAVA_CLASS_VERSION, MAXIMUM_JAVA_CLASS_VERSION));
 
     private static final Logger LOGGER = Logger.getLogger(Main.class.getName());
 


### PR DESCRIPTION
As of https://github.com/jenkinsci/jenkins/pull/6600 I cannot think of any reason _not_ to run Jenkins with Java 17: it works better than Java 11 in every case I am aware of. So let us allow users to use Java 17 without having to pass the scary `--enable-future-java` flag. I plan to mention in the blog post announcing the requirement of Java 11 that we're also taking Java 17 out of preview mode. I also plan to filing PRs to the Docker and Packaging repositories to remove the "preview" label from the Java 17 images around the same time.

### Testing done

Verified that I no longer need `--enable-future-java` to start Jenkins on Java 17 but that I still need it when starting with Java 16 or Java 18.